### PR TITLE
Fix team chest reset on continue and add configurable rows (mc1.21.11)

### DIFF
--- a/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/TeamChestConfig.java
+++ b/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/TeamChestConfig.java
@@ -1,0 +1,78 @@
+package me.chengzhify.yetanotherbingoteamchest;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class TeamChestConfig {
+
+    private static final String FILE_NAME = "yetanotherbingo-teamchest.toml";
+    private static final String TEMPLATE_NAME = "yetanotherbingo-teamchest-default.toml";
+    private static final Pattern ROWS_PATTERN = Pattern.compile("^\\s*rows\\s*=\\s*(\\d+)\\s*(#.*)?$");
+
+    private static final int DEFAULT_ROWS = 3;
+    private static final int MIN_ROWS = 1;
+    private static final int MAX_ROWS = 6;
+
+    private static int rows = DEFAULT_ROWS;
+
+    private TeamChestConfig() {}
+
+    public static void load() {
+        Path configPath = FabricLoader.getInstance().getConfigDir().resolve(FILE_NAME);
+
+        try {
+            copyTemplateIfMissing(configPath);
+            rows = parseRows(configPath);
+        } catch (IOException e) {
+            rows = DEFAULT_ROWS;
+            System.err.println("[YetAnotherBingo-TeamChest] Failed to load config, using default rows=" + DEFAULT_ROWS);
+            e.printStackTrace();
+        }
+    }
+
+    public static int getRows() {
+        return rows;
+    }
+
+    public static int getSize() {
+        return rows * 9;
+    }
+
+    private static void copyTemplateIfMissing(Path configPath) throws IOException {
+        if (Files.exists(configPath)) {
+            return;
+        }
+
+        Files.createDirectories(configPath.getParent());
+        try (InputStream input = TeamChestConfig.class.getClassLoader().getResourceAsStream(TEMPLATE_NAME)) {
+            if (input == null) {
+                throw new IOException("Missing config template resource: " + TEMPLATE_NAME);
+            }
+            Files.copy(input, configPath);
+        }
+    }
+
+    private static int parseRows(Path configPath) throws IOException {
+        List<String> lines = Files.readAllLines(configPath, StandardCharsets.UTF_8);
+        for (String line : lines) {
+            Matcher matcher = ROWS_PATTERN.matcher(line);
+            if (matcher.matches()) {
+                return clampRows(Integer.parseInt(matcher.group(1)));
+            }
+        }
+
+        return DEFAULT_ROWS;
+    }
+
+    private static int clampRows(int value) {
+        return Math.max(MIN_ROWS, Math.min(MAX_ROWS, value));
+    }
+}

--- a/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/TeamChestConfig.java
+++ b/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/TeamChestConfig.java
@@ -7,43 +7,73 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public final class TeamChestConfig {
 
     private static final String FILE_NAME = "yetanotherbingo-teamchest.toml";
     private static final String TEMPLATE_NAME = "yetanotherbingo-teamchest-default.toml";
-    private static final Pattern ROWS_PATTERN = Pattern.compile("^\\s*rows\\s*=\\s*(\\d+)\\s*(#.*)?$");
+    private static final String SECTION_TEAM_CHEST = "team_chest";
+    private static final String SECTION_TEAM_TELEPORT = "team_teleport";
 
     private static final int DEFAULT_ROWS = 3;
     private static final int MIN_ROWS = 1;
     private static final int MAX_ROWS = 6;
+    private static final boolean DEFAULT_TEAM_CHEST_ENABLED = true;
+    private static final boolean DEFAULT_TEAM_TELEPORT_ENABLED = true;
 
     private static int rows = DEFAULT_ROWS;
+    private static boolean teamChestEnabled = DEFAULT_TEAM_CHEST_ENABLED;
+    private static boolean teamTeleportEnabled = DEFAULT_TEAM_TELEPORT_ENABLED;
 
     private TeamChestConfig() {}
 
-    public static void load() {
-        Path configPath = FabricLoader.getInstance().getConfigDir().resolve(FILE_NAME);
+    public static synchronized void load() {
+        Path configPath = getConfigPath();
 
         try {
             copyTemplateIfMissing(configPath);
-            rows = parseRows(configPath);
+            parseConfig(configPath);
         } catch (IOException e) {
             rows = DEFAULT_ROWS;
-            System.err.println("[YetAnotherBingo-TeamChest] Failed to load config, using default rows=" + DEFAULT_ROWS);
+            teamChestEnabled = DEFAULT_TEAM_CHEST_ENABLED;
+            teamTeleportEnabled = DEFAULT_TEAM_TELEPORT_ENABLED;
+            System.err.println("[YetAnotherBingo-TeamChest] Failed to load config, using default values.");
             e.printStackTrace();
         }
     }
 
-    public static int getRows() {
+    public static synchronized int getRows() {
         return rows;
     }
 
-    public static int getSize() {
+    public static synchronized int getSize() {
         return rows * 9;
+    }
+
+    public static synchronized boolean isTeamChestEnabled() {
+        return teamChestEnabled;
+    }
+
+    public static synchronized boolean isTeamTeleportEnabled() {
+        return teamTeleportEnabled;
+    }
+
+    public static synchronized void persistToggleStates(boolean teamChestEnabled, boolean teamTeleportEnabled) {
+        TeamChestConfig.teamChestEnabled = teamChestEnabled;
+        TeamChestConfig.teamTeleportEnabled = teamTeleportEnabled;
+
+        try {
+            writeConfig(getConfigPath());
+        } catch (IOException e) {
+            System.err.println("[YetAnotherBingo-TeamChest] Failed to persist toggle config.");
+            e.printStackTrace();
+        }
+    }
+
+    private static Path getConfigPath() {
+        return FabricLoader.getInstance().getConfigDir().resolve(FILE_NAME);
     }
 
     private static void copyTemplateIfMissing(Path configPath) throws IOException {
@@ -60,16 +90,93 @@ public final class TeamChestConfig {
         }
     }
 
-    private static int parseRows(Path configPath) throws IOException {
+    private static void parseConfig(Path configPath) throws IOException {
         List<String> lines = Files.readAllLines(configPath, StandardCharsets.UTF_8);
+        int parsedRows = DEFAULT_ROWS;
+        boolean parsedTeamChestEnabled = DEFAULT_TEAM_CHEST_ENABLED;
+        boolean parsedTeamTeleportEnabled = DEFAULT_TEAM_TELEPORT_ENABLED;
+        String section = "";
+
         for (String line : lines) {
-            Matcher matcher = ROWS_PATTERN.matcher(line);
-            if (matcher.matches()) {
-                return clampRows(Integer.parseInt(matcher.group(1)));
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+
+            if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+                section = trimmed.substring(1, trimmed.length() - 1).trim();
+                continue;
+            }
+
+            String content = stripInlineComment(trimmed);
+            int eqIndex = content.indexOf('=');
+            if (eqIndex <= 0) {
+                continue;
+            }
+
+            String key = content.substring(0, eqIndex).trim();
+            String value = content.substring(eqIndex + 1).trim();
+
+            if (SECTION_TEAM_CHEST.equals(section)) {
+                if ("rows".equals(key)) {
+                    try {
+                        parsedRows = Integer.parseInt(value);
+                    } catch (NumberFormatException ignored) {
+                        parsedRows = DEFAULT_ROWS;
+                    }
+                } else if ("enabled".equals(key)) {
+                    parsedTeamChestEnabled = parseBoolean(value, DEFAULT_TEAM_CHEST_ENABLED);
+                }
+            } else if (SECTION_TEAM_TELEPORT.equals(section) && "enabled".equals(key)) {
+                parsedTeamTeleportEnabled = parseBoolean(value, DEFAULT_TEAM_TELEPORT_ENABLED);
             }
         }
 
-        return DEFAULT_ROWS;
+        rows = clampRows(parsedRows);
+        teamChestEnabled = parsedTeamChestEnabled;
+        teamTeleportEnabled = parsedTeamTeleportEnabled;
+    }
+
+    private static String stripInlineComment(String line) {
+        int index = line.indexOf('#');
+        if (index < 0) {
+            return line;
+        }
+        return line.substring(0, index).trim();
+    }
+
+    private static boolean parseBoolean(String value, boolean defaultValue) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        return defaultValue;
+    }
+
+    private static void writeConfig(Path configPath) throws IOException {
+        Files.createDirectories(configPath.getParent());
+        String content = "# YetAnotherBingo-TeamChest configuration\n"
+                + "\n"
+                + "[team_chest]\n"
+                + "# Team chest rows. Valid range: 1..6\n"
+                + "rows = " + rows + "\n"
+                + "# Whether /teamchest and /tc are enabled\n"
+                + "enabled = " + teamChestEnabled + "\n"
+                + "\n"
+                + "[team_teleport]\n"
+                + "# Whether /teamtp and /ttp are enabled\n"
+                + "enabled = " + teamTeleportEnabled + "\n";
+
+        Files.writeString(
+                configPath,
+                content,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE
+        );
     }
 
     private static int clampRows(int value) {

--- a/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/YetAnotherBingoTeamChest.java
+++ b/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/YetAnotherBingoTeamChest.java
@@ -38,6 +38,8 @@ public class YetAnotherBingoTeamChest implements ModInitializer {
     public void onInitialize() {
         ADAPTER = VersionAdapterProvider.get();
         TeamChestConfig.load();
+        tcEnabled = TeamChestConfig.isTeamChestEnabled();
+        tpEnabled = TeamChestConfig.isTeamTeleportEnabled();
         ServerLifecycleEvents.SERVER_STARTED.register(s -> server = s);
         ServerLifecycleEvents.SERVER_STOPPED.register(s -> server = null);
         registerCommands();
@@ -249,6 +251,7 @@ public class YetAnotherBingoTeamChest implements ModInitializer {
 
     private int tcToggle(CommandContext<ServerCommandSource> ctx) {
         tcEnabled = !tcEnabled;
+        TeamChestConfig.persistToggleStates(tcEnabled, tpEnabled);
 
         ctx.getSource().sendFeedback(
                 () -> Text.translatableWithFallback("yetanotherbingo-teamchest.message.toggle", "Team chest is now ")
@@ -268,6 +271,7 @@ public class YetAnotherBingoTeamChest implements ModInitializer {
 
     private int tpToggle(CommandContext<ServerCommandSource> ctx) {
         tpEnabled = !tpEnabled;
+        TeamChestConfig.persistToggleStates(tcEnabled, tpEnabled);
 
         ctx.getSource().sendFeedback(
                 () -> Text.translatableWithFallback("yetanotherbingo-teamchest.message.tptoggle", "Team teleport is now ")

--- a/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/YetAnotherBingoTeamChest.java
+++ b/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/YetAnotherBingoTeamChest.java
@@ -37,6 +37,7 @@ public class YetAnotherBingoTeamChest implements ModInitializer {
     @Override
     public void onInitialize() {
         ADAPTER = VersionAdapterProvider.get();
+        TeamChestConfig.load();
         ServerLifecycleEvents.SERVER_STARTED.register(s -> server = s);
         ServerLifecycleEvents.SERVER_STOPPED.register(s -> server = null);
         registerCommands();

--- a/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/YetAnotherBingoTeamChest.java
+++ b/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/YetAnotherBingoTeamChest.java
@@ -239,11 +239,6 @@ public class YetAnotherBingoTeamChest implements ModInitializer {
     }
 
     private void registerBingoHooks() {
-        BingoEvents.GAME_ENDED.register((e) -> {
-            if (server != null) {
-                ADAPTER.clearAllTeamInventories(server);
-            }
-        });
         BingoEvents.GAME_RESET.register((e) -> {
             if (server != null) {
                 ADAPTER.clearAllTeamInventories(server);

--- a/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/adapter/impl/BingoVersionAdapterImpl.java
+++ b/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/adapter/impl/BingoVersionAdapterImpl.java
@@ -1,9 +1,12 @@
 package me.chengzhify.yetanotherbingoteamchest.adapter.impl;
 
+import me.chengzhify.yetanotherbingoteamchest.TeamChestConfig;
 import me.chengzhify.yetanotherbingoteamchest.adapter.VersionAdapter;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.SimpleNamedScreenHandlerFactory;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -14,7 +17,7 @@ import net.minecraft.world.PersistentState;
 public class BingoVersionAdapterImpl implements VersionAdapter {
 
     public Inventory createTeamInventory() {
-        return new SimpleInventory(27);
+        return new SimpleInventory(TeamChestConfig.getSize());
     }
 
     public void clearAllTeamInventories(MinecraftServer server) {
@@ -29,10 +32,24 @@ public class BingoVersionAdapterImpl implements VersionAdapter {
         player.openHandledScreen(
                 new SimpleNamedScreenHandlerFactory(
                         (syncId, inv, p) ->
-                                GenericContainerScreenHandler.createGeneric9x3(syncId, inv, inventory),
+                                createScreenHandler(syncId, inv, inventory),
                         title
                 )
         );
+    }
+
+    private GenericContainerScreenHandler createScreenHandler(int syncId, PlayerInventory playerInventory, Inventory chestInventory) {
+        int rows = TeamChestConfig.getRows();
+        ScreenHandlerType<GenericContainerScreenHandler> type = switch (rows) {
+            case 1 -> ScreenHandlerType.GENERIC_9X1;
+            case 2 -> ScreenHandlerType.GENERIC_9X2;
+            case 4 -> ScreenHandlerType.GENERIC_9X4;
+            case 5 -> ScreenHandlerType.GENERIC_9X5;
+            case 6 -> ScreenHandlerType.GENERIC_9X6;
+            default -> ScreenHandlerType.GENERIC_9X3;
+        };
+
+        return new GenericContainerScreenHandler(type, syncId, playerInventory, chestInventory, rows);
     }
 
     public Text literal(String text) {
@@ -45,5 +62,3 @@ public class BingoVersionAdapterImpl implements VersionAdapter {
 
 
 }
-
-

--- a/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/adapter/impl/TeamChestStateImpl.java
+++ b/mc1.21.11/src/main/java/me/chengzhify/yetanotherbingoteamchest/adapter/impl/TeamChestStateImpl.java
@@ -2,6 +2,7 @@ package me.chengzhify.yetanotherbingoteamchest.adapter.impl;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import me.chengzhify.yetanotherbingoteamchest.TeamChestConfig;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
@@ -31,7 +32,7 @@ public class TeamChestStateImpl extends PersistentState {
 
     public SimpleInventory getInventory(String teamId) {
         return teamInventories.computeIfAbsent(teamId, id -> {
-            SimpleInventory inv = new SimpleInventory(27);
+            SimpleInventory inv = new SimpleInventory(TeamChestConfig.getSize());
             inv.addListener(sender -> this.markDirty());
             return inv;
         });

--- a/mc1.21.11/src/main/resources/yetanotherbingo-teamchest-default.toml
+++ b/mc1.21.11/src/main/resources/yetanotherbingo-teamchest-default.toml
@@ -1,0 +1,5 @@
+# YetAnotherBingo-TeamChest configuration
+
+[team_chest]
+# Team chest rows. Valid range: 1..6
+rows = 3

--- a/mc1.21.11/src/main/resources/yetanotherbingo-teamchest-default.toml
+++ b/mc1.21.11/src/main/resources/yetanotherbingo-teamchest-default.toml
@@ -3,3 +3,9 @@
 [team_chest]
 # Team chest rows. Valid range: 1..6
 rows = 3
+# Whether /teamchest and /tc are enabled
+enabled = true
+
+[team_teleport]
+# Whether /teamtp and /ttp are enabled
+enabled = true


### PR DESCRIPTION
## Summary
- Fixes the regression where team chest data was cleared on `GAME_ENDED`, which broke "continue playing" flow in YetAnotherBingo.
- Adds a TOML config scaffold for `mc1.21.11` that copies a default template into `config/yetanotherbingo-teamchest.toml`.
- Applies configurable chest rows (1..6) to both persisted inventory size and opened container UI for team chests.
- Persists `/teamchest toggle` and `/tptoggle` states in the same TOML config (`team_chest.enabled` and `team_teleport.enabled`).

## Validation
- Built successfully with: `bash ./gradlew :mc1.21.11:build --no-daemon`
- Manual verification confirmed continue flow now preserves team chest items.